### PR TITLE
feat: Implement Poly-proline (PPII) Helix Calculation

### DIFF
--- a/src/io.py
+++ b/src/io.py
@@ -1,5 +1,5 @@
 from Bio.PDB import PDBParser, MMCIFParser
-from dsspy.core import Residue, ChainBreakType
+from core import Residue, ChainBreakType
 
 def extract_residues(structure):
     """

--- a/src/output.py
+++ b/src/output.py
@@ -1,5 +1,5 @@
 import datetime
-from dsspy.core import Residue, StructureType, HelixType, HelixPositionType
+from core import Residue, StructureType, HelixType, HelixPositionType
 
 # 3-to-1 letter code for amino acids
 AA_CODES = {

--- a/tests/test_pp_helices.py
+++ b/tests/test_pp_helices.py
@@ -1,0 +1,38 @@
+from core import StructureType, HelixType, HelixPositionType
+from algorithm import calculate_pp_helices
+
+class MockResidue:
+    def __init__(self, phi, psi):
+        self.phi = phi
+        self.psi = psi
+        self.secondary_structure = StructureType.LOOP
+        self.helix_flags = {helix_type: HelixPositionType.NONE for helix_type in HelixType}
+
+def test_calculate_pp_helices():
+    """
+    Tests the calculate_pp_helices function with the C++ ported logic.
+    """
+    # Create a list of mock residues with phi/psi angles for a PPII helix
+    residues = [MockResidue(-75, 145) for _ in range(7)]
+    residues[0].phi = 0 # Not in helix
+    residues[6].phi = 0 # Not in helix
+
+    calculate_pp_helices(residues, stretch_length=3)
+
+    # Expected state based on the quirky C++ loop (for i in 1..n-4):
+    # N, S, M, M, M, E, N
+    assert residues[0].helix_flags[HelixType.PP] == HelixPositionType.NONE
+    assert residues[1].helix_flags[HelixType.PP] == HelixPositionType.START
+    assert residues[2].helix_flags[HelixType.PP] == HelixPositionType.MIDDLE
+    assert residues[3].helix_flags[HelixType.PP] == HelixPositionType.MIDDLE
+    assert residues[4].helix_flags[HelixType.PP] == HelixPositionType.MIDDLE
+    assert residues[5].helix_flags[HelixType.PP] == HelixPositionType.END
+    assert residues[6].helix_flags[HelixType.PP] == HelixPositionType.NONE
+
+    assert residues[0].secondary_structure == StructureType.LOOP
+    assert residues[1].secondary_structure == StructureType.HELIX_PPII
+    assert residues[2].secondary_structure == StructureType.HELIX_PPII
+    assert residues[3].secondary_structure == StructureType.HELIX_PPII
+    assert residues[4].secondary_structure == StructureType.HELIX_PPII
+    assert residues[5].secondary_structure == StructureType.HELIX_PPII
+    assert residues[6].secondary_structure == StructureType.LOOP


### PR DESCRIPTION
This commit introduces the functionality to calculate Poly-proline II (PPII) helices based on phi/psi torsion angles.

The core of this change is the new `calculate_pp_helices` function in `src/algorithm.py`, which is a faithful port of the logic from the original C++ `dssp.cpp` implementation. This includes the specific iteration logic used in the C++ version.

To support this new feature and the existing code structure, the following changes were made:
- Intra-module imports within the `src` directory were updated to be absolute from `src` (e.g., `from core import ...`). This was necessary to allow tests to run correctly without restructuring the entire project.
- A new, isolated test file, `tests/test_pp_helices.py`, has been added to validate the new function. This test uses mock objects to ensure the function's logic is correct without relying on the broken parts of the existing test suite.

The existing broken test `test_calculate_h_bonds_comparative` was not modified as fixing it was determined to be out of scope for this task.