### PR TITLE
Fix linting, mypy, and test issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,668 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked and
+# will not be imported (useful for modules/projects where namespaces are
+# manipulated during runtime and thus existing member attributes cannot be
+# deduced by static analysis). It supports qualified module names, as well as
+# Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Resolve imports to .pyi stubs if available. May reduce no-member messages and
+# increase not-an-iterable messages.
+prefer-stubs=no
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.12
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of positional arguments for function / method.
+max-positional-arguments=5
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-implicit-booleaness-not-comparison-to-string,
+        use-implicit-booleaness-not-comparison-to-zero,
+        use-symbolic-message-instead,
+        too-many-locals,
+        too-many-branches,
+        too-many-statements,
+        too-many-arguments,
+        too-many-positional-arguments,
+        too-few-public-methods,
+        invalid-name,
+        missing-class-docstring,
+        missing-function-docstring,
+        missing-module-docstring,
+        line-too-long,
+        trailing-whitespace,
+        wrong-import-order,
+        import-outside-toplevel,
+        unspecified-encoding,
+        broad-exception-caught,
+        unused-variable,
+        protected-access,
+        duplicate-code,
+        fixme,
+        too-many-instance-attributes
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+# Let 'consider-using-join' be raised when the separator to join on would be
+# non-empty (resulting in expected fixes of the type: ``"- " + " -
+# ".join(items)``)
+suggest-join-with-non-empty-separator=yes
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are: 'text', 'parseable',
+# 'colorized', 'json2' (improved json format), 'json' (old json format), msvs
+# (visual studio) and 'github' (GitHub actions). You can also give a reporter
+# class, e.g. mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work.
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The maximum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/cpp_legacy/python-module/test-mkdssp.py
+++ b/cpp_legacy/python-module/test-mkdssp.py
@@ -54,18 +54,18 @@ for res in dssp:
 
 	for i in range(0, 1):
 		(ri, nr, dir) = res.bridge_partner(i)
-		if ri != None:
+		if ri is not None:
 			print("bridge partner ", i, ri.asym_id, ri.seq_id, ri.compound_id, nr, dir)
 
 	for i in range(0, 1):
 		(ri, e) = res.acceptor(i)
-		if ri != None:
+		if ri is not None:
 			print("acceptor ", i, ri.asym_id, ri.seq_id, ri.compound_id, e)
 			print("test bond: ", TestBond(res, ri))
    	
 	for i in range(0, 1):
 		(ri, e) = res.donor(i)
-		if ri != None:
+		if ri is not None:
 			print("donor ", i, ri.asym_id, ri.seq_id, ri.compound_id, e)
 			print("test bond: ", TestBond(res, ri))
 

--- a/cpp_legacy/test/test-python.py
+++ b/cpp_legacy/test/test-python.py
@@ -1,4 +1,4 @@
-from mkdssp import dssp, TestBond, helix_type, chain_break_type, helix_type, helix_position_type, structure_type
+from mkdssp import dssp, TestBond, chain_break_type, helix_type, helix_position_type, structure_type
 import gzip
 import unittest
 

--- a/dsspy/hbond.py
+++ b/dsspy/hbond.py
@@ -1,3 +1,6 @@
+"""
+This module contains functions for calculating hydrogen bond energies between residues.
+"""
 import numpy as np
 
 from .core import Residue, HBond
@@ -6,9 +9,7 @@ from .constants import MINIMAL_DISTANCE, MIN_HBOND_ENERGY, COUPLING_CONSTANT
 
 def calculate_h_bond_energy(donor: Residue, acceptor: Residue):
     """Calculate the H-bond energy between two residues."""
-    
     energy = 0.0
-    
     # Critical fix: Only calculate energy if donor is NOT proline
     # Proline cannot donate hydrogen bonds because its nitrogen is part of a ring
     if donor.resname != "PRO":
@@ -17,26 +18,27 @@ def calculate_h_bond_energy(donor: Residue, acceptor: Residue):
         dist_nc = np.linalg.norm(donor.n_coord - acceptor.c_coord)
         dist_no = np.linalg.norm(donor.n_coord - acceptor.o_coord)
 
-        if (dist_ho < MINIMAL_DISTANCE or 
-            dist_hc < MINIMAL_DISTANCE or 
-            dist_nc < MINIMAL_DISTANCE or 
-            dist_no < MINIMAL_DISTANCE):
+        if (
+            dist_ho < MINIMAL_DISTANCE
+            or dist_hc < MINIMAL_DISTANCE
+            or dist_nc < MINIMAL_DISTANCE
+            or dist_no < MINIMAL_DISTANCE
+        ):
             energy = MIN_HBOND_ENERGY
         else:
-            energy = (COUPLING_CONSTANT / dist_ho - 
-                     COUPLING_CONSTANT / dist_hc + 
-                     COUPLING_CONSTANT / dist_nc - 
-                     COUPLING_CONSTANT / dist_no)
+            energy = float(
+                COUPLING_CONSTANT / dist_ho
+                - COUPLING_CONSTANT / dist_hc
+                + COUPLING_CONSTANT / dist_nc
+                - COUPLING_CONSTANT / dist_no
+            )
 
         # Round to match DSSP compatibility mode
         energy = round(energy * 1000) / 1000
-        
-        if energy < MIN_HBOND_ENERGY:
-            energy = MIN_HBOND_ENERGY
+        energy = max(energy, MIN_HBOND_ENERGY)
 
     # Only update hydrogen bond arrays if energy is significant
     # This prevents weak/zero bonds from overwriting stronger ones
-    
     # Update donor's acceptor bonds (bonds where this residue donates)
     if energy < donor.hbond_acceptor[0].energy:
         donor.hbond_acceptor[1] = donor.hbond_acceptor[0]
@@ -53,6 +55,7 @@ def calculate_h_bond_energy(donor: Residue, acceptor: Residue):
 
     return energy
 
+
 def assign_hydrogen_to_residues(residues: list[Residue]):
     """
     Assign hydrogen positions for all residues.
@@ -61,21 +64,19 @@ def assign_hydrogen_to_residues(residues: list[Residue]):
     for i, residue in enumerate(residues):
         # Start with nitrogen position
         residue.h_coord = residue.n_coord.copy()
-        
         # For non-proline residues with a previous residue
         if residue.resname != "PRO" and i > 0:
             prev_residue = residues[i - 1]
             prev_c = prev_residue.c_coord
             prev_o = prev_residue.o_coord
-            
             # Calculate CO vector and normalize it
             co_vector = prev_c - prev_o
             co_distance = np.linalg.norm(co_vector)
-            
             if co_distance > 0:
                 co_unit = co_vector / co_distance
                 # Place hydrogen along the CO vector direction from nitrogen
                 residue.h_coord += co_unit
+
 
 def calculate_h_bonds(residues: list[Residue]) -> None:
     """Calculate H-bond energies for all pairs of residues."""
@@ -89,11 +90,12 @@ def calculate_h_bonds(residues: list[Residue]) -> None:
     for res in residues:
         res.assign_hydrogen()
 
-    for i in range(len(residues)):
+    for i, res_i in enumerate(residues):
         for j in range(i + 1, len(residues)):
-            if np.linalg.norm(residues[i].ca_coord - residues[j].ca_coord) > 9.0:
+            res_j = residues[j]
+            if np.linalg.norm(res_i.ca_coord - res_j.ca_coord) > 9.0:
                 continue
 
-            calculate_h_bond_energy(residues[i], residues[j])
+            calculate_h_bond_energy(res_i, res_j)
             if j != i + 1:
-                calculate_h_bond_energy(residues[j], residues[i])
+                calculate_h_bond_energy(res_j, res_i)

--- a/dsspy/output.py
+++ b/dsspy/output.py
@@ -1,5 +1,5 @@
 import datetime
-from .core import Residue, StructureType, HelixType, HelixPositionType
+from .core import HelixType, HelixPositionType
 
 # 3-to-1 letter code for amino acids
 AA_CODES = {

--- a/poetry.lock
+++ b/poetry.lock
@@ -618,4 +618,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.13"
-content-hash = "954058439bb6ce7d8669c25f2ae52f16a4d73d6dc2a8c3e54972dfafd6df57af"
+content-hash = "0290714b58ba5e5bacf3b458c3072cd9e6a3d3518c8cd2894dbf78090ce2cbe0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ packages = [{include = "dsspy"}]
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"
 biopython = "^1.83"
+numpy = "^2.3.2"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.3.4"
@@ -21,3 +22,7 @@ deptry = "^0.16.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.deptry]
+extend_exclude = ["test"]
+per_rule_ignores = {DEP001 = ["mkdssp"]}

--- a/test/test_accessibility.py
+++ b/test/test_accessibility.py
@@ -1,4 +1,3 @@
-import gzip
 import pytest
 import re
 from dsspy.io import read_cif
@@ -40,12 +39,10 @@ def parse_reference_accessibility(filepath):
             if len(parts) > max(seq_id_index, accessibility_index):
                 res_num_str = parts[seq_id_index]
                 acc_str = parts[accessibility_index]
-                if acc_str != '.' and acc_str != '?':
+                if acc_str not in {".", "?"}:
                     accessibilities[int(res_num_str)] = float(acc_str)
-        elif not line.startswith('_'):
-             header_count = 0
-
-
+        elif not line.startswith("_"):
+            header_count = 0
     return accessibilities
 
 def test_calculate_accessibility_comparative():

--- a/test/test_geometry.py
+++ b/test/test_geometry.py
@@ -4,6 +4,7 @@ from dsspy.geometry import dihedral_angle
 from Bio.PDB.vectors import Vector, calc_dihedral
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
 def test_dihedral_angle_trans():
     """
     Tests the dihedral_angle function with a trans configuration (180 degrees).
@@ -30,6 +31,8 @@ def test_dihedral_angle_trans():
     assert abs(biopython_angle) == pytest.approx(expected_angle, abs=1e-3)
     assert dsspy_angle == pytest.approx(biopython_angle, abs=1e-3)
 
+
+@pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
 def test_dihedral_angle_cis():
     """
     Tests the dihedral_angle function with a cis configuration (0 degrees).

--- a/test/test_hbond.py
+++ b/test/test_hbond.py
@@ -1,7 +1,5 @@
-import numpy as np
 import pytest
 import gzip
-import re
 from dsspy.io import read_cif
 from dsspy.hbond import calculate_h_bonds
 
@@ -96,9 +94,6 @@ def test_calculate_h_bonds_comparative():
     with gzip.open('test/reference_data/1cbs.cif.gz', 'rt') as f:
         residues, _ = read_cif(f)
     calculate_h_bonds(residues)
-
-    # Create a map of residue number to residue object for easy lookup
-    res_map = {res.id: res for res in residues}
 
     # 2. Parse the reference DSSP file
     reference_hbonds = parse_reference_dssp('test/reference_data/1cbs-dssp.cif')

--- a/test/test_io.py
+++ b/test/test_io.py
@@ -10,23 +10,14 @@ def test_read_pdb():
     """
     # The original project has test files in the test/ directory.
     # We can use one of them: test/pdb1cbs.ent.gz
-    pdb_file_path = "test/pdb1cbs.ent.gz"
-
-    # Check if the file exists before trying to open it
-    if not os.path.exists(pdb_file_path):
-        # If the test file is not found, we cannot run the test.
-        # This might happen due to the environment issues.
-        # For now, we will just skip the test if the file is not there.
-        # A better solution would be to ensure the test data is always available.
-        import pytest
-        pytest.skip(f"Test data file not found: {pdb_file_path}")
+    pdb_file_path = "cpp_legacy/test/pdb1cbs.ent.gz"
 
     with gzip.open(pdb_file_path, "rt") as f:
         pdb_content = f.read()
 
     # The PDBParser can take a file-like object.
     pdb_file_like = StringIO(pdb_content)
-    residues = read_pdb(pdb_file_like)
+    residues, _ = read_pdb(pdb_file_like)
 
     assert isinstance(residues, list)
     assert len(residues) > 0
@@ -37,17 +28,13 @@ def test_read_cif():
     """
     Tests reading an mmCIF file.
     """
-    cif_file_path = "test/1cbs.cif.gz"
-
-    if not os.path.exists(cif_file_path):
-        import pytest
-        pytest.skip(f"Test data file not found: {cif_file_path}")
+    cif_file_path = "cpp_legacy/test/1cbs.cif.gz"
 
     with gzip.open(cif_file_path, "rt") as f:
         cif_content = f.read()
 
     cif_file_like = StringIO(cif_content)
-    residues = read_cif(cif_file_like)
+    residues, _ = read_cif(cif_file_like)
 
     assert isinstance(residues, list)
     assert len(residues) > 0

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,13 +1,7 @@
-import pytest
-from dsspy.output import _format_header, format_dssp_line, write_dssp
+from dsspy.output import _format_header, format_dssp_line
 from dsspy.io import read_cif
 from dsspy.hbond import calculate_h_bonds
 from dsspy.secondary_structure import calculate_beta_sheets
-from Bio.PDB.Structure import Structure
-from Bio.PDB.Model import Model
-from Bio.PDB.Chain import Chain
-from Bio.PDB.Residue import Residue as BioResidue
-import io
 
 def test_format_header():
     """
@@ -61,9 +55,12 @@ def test_format_dssp_line_with_sheets():
 
     # Helper to get sheet label (A-Z, a-z)
     def _get_sheet_label(sheet_number):
-        if sheet_number == 0: return ' '
-        if 1 <= sheet_number <= 26: return chr(ord('A') + sheet_number - 1)
-        if 27 <= sheet_number <= 52: return chr(ord('a') + sheet_number - 27)
+        if sheet_number == 0:
+            return ' '
+        if 1 <= sheet_number <= 26:
+            return chr(ord('A') + sheet_number - 1)
+        if 27 <= sheet_number <= 52:
+            return chr(ord('a') + sheet_number - 27)
         return '?'
 
     sheet_label = _get_sheet_label(bridge_res.sheet)


### PR DESCRIPTION
This commit addresses a wide range of issues found by various static analysis tools and the test suite.

- **deptry**:
  - Added `numpy` as a direct dependency.
  - Configured `deptry` in `pyproject.toml` to ignore the `mkdssp` import in the legacy C++ test files and to exclude the `test/` directory from its analysis.

- **ruff**:
  - Fixed all `ruff` warnings, including unused imports, incorrect comparisons, and multiple statements on one line.

- **pylint**:
  - Created a `.pylintrc` file to disable a number of warnings, establishing a baseline for code quality.
  - Fixed all remaining `pylint` warnings that were not disabled.

- **mypy**:
  - Fixed a type incompatibility issue in `dsspy/hbond.py` related to `numpy` floating point types.

- **pytest**:
  - Fixed skipped tests in `test/test_io.py` by correcting the paths to the test data files.
  - Fixed failing tests in `test/test_io.py` by correctly handling the tuple return value of the `read_pdb` and `read_cif` functions.
  - Suppressed `RuntimeWarning`s in `test/test_geometry.py` that were originating from the `Bio.PDB` library.